### PR TITLE
Make resolveOnUri configurable from the redirect callback

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -25,7 +25,7 @@ export class Oauth {
         const url = provider.dialogUrl();
 
         return this.openDialog(url, utils.defaults(windowOptions, this.defaultWindowOptions), {
-          resolveOnUri: provider.options.redirectUri,
+          resolveOnUri: provider.options.resolveOnUri || provider.options.redirectUri,
           providerName: provider.name
         }).then((event) => {
           return provider.parseResponseInUrl(event.url);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -7,6 +7,7 @@ export interface IOAuthOptions {
     clientId?: string;
     appScope?: string[];
     redirectUri?: string;
+    resolveOnUri?: string;
     responseType?: string;
     state?: string;
 }


### PR DESCRIPTION
The reason for this is when you want to use this library from the browser and not the phone and the redirect uri goes to a different domain than your current one. You want to be able to make the url that you listen on CORS compatible.