### PR TITLE
Make resolveOnUri configurable from the redirect callback

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -25,7 +25,7 @@ export class Oauth {
         const url = provider.dialogUrl();
 
         return this.openDialog(url, utils.defaults(windowOptions, this.defaultWindowOptions), {
-          resolveOnUri: provider.options.redirectUri,
+          resolveOnUri: provider.options.resolveOnUri || provider.options.redirectUri,
           providerName: provider.name
         }).then((event) => {
           return provider.parseResponseInUrl(event.url);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -7,6 +7,7 @@ export interface IOAuthOptions {
     clientId?: string;
     appScope?: string[];
     redirectUri?: string;
+    resolveOnUri?: string;
     responseType?: string;
     state?: string;
 }


### PR DESCRIPTION
The reason for this is when you want to use this library from the browser and not the phone and the redirect uri goes to a different domain than your current one. You want to be able to make the url that you listen on CORS compatible.

Confirming that this is indeed a change that is useful for our use case, but let me know how you feel about it.  I'll outline the scenario below:

```
client (app1.domain.com) 
              VV
start login process with provider (salesforce) where callbackUrl is set to auth.domain.com
              VV
auth.domain.com takes token and redirects to client (app1.domain.com)
              VV
!! this is where having resolveOnUri configurable is important !! 
client popup window listens for app1.domain.com (not the redirectUri) when doing the noop to grab the token
              VV
do whatever with token you want after
```