### PR TITLE
fix(redirect-uri): wraps redirectUri parameter with encodeURIComponent

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -49,7 +49,7 @@ export class OAuthProvider implements IOauthProvider {
 
     protected optionsToDialogUrl(options: any): string {
         utils.defaults(options, this.defaults)
-        let url = `${this.authUrl}?client_id=${options.clientId}&redirect_uri=${options.redirectUri}`;
+        let url = `${this.authUrl}?client_id=${options.clientId}&redirect_uri=${encodeURIComponent(options.redirectUri)}`;
 
         if (options.appScope) {
             url += `&scope=${this.serializeAppScope(options.appScope)}`;


### PR DESCRIPTION
This ensures that user can pass redirect url with custom get parameters (e.g. http://my.site.com?mobile=1)