### PR TITLE
Return when resolving so that another setTimeout isn't executed.

### DIFF
--- a/src/platform/browser.ts
+++ b/src/platform/browser.ts
@@ -31,7 +31,7 @@ export class OauthBrowser extends Oauth {
 
               if (popup.location.href.indexOf(options.resolveOnUri) === 0) {
                 popup.close();
-                resolve({ url: popup.location.href });
+                return resolve({ url: popup.location.href });
               }
             } catch (e) {
             }


### PR DESCRIPTION
This prevents the possibility of a reject also being called on the subsequent timeout (noticed on Win8.1/IE11).